### PR TITLE
Revert "Add ability to specify logToHandler per function"

### DIFF
--- a/lib/__snapshots__/setupLogGroupSubscriptions.test.js.snap
+++ b/lib/__snapshots__/setupLogGroupSubscriptions.test.js.snap
@@ -1,5 +1,29 @@
 exports[`Setup LogGroup Subscriptions should setup log group subscriptions 1`] = `
 Object {
+  "LoggingLambdaPermission": Object {
+    "Properties": Object {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": Object {
+        "Fn::GetAtt": Array [
+          "LogHandlerLambdaFunction",
+          "Arn",
+        ],
+      },
+      "Principal": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "logs.",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            ".amazonaws.com",
+          ],
+        ],
+      },
+    },
+    "Type": "AWS::Lambda::Permission",
+  },
   "TestingLambdaFunctionSubscriptionFilter": Object {
     "DependsOn": "LoggingLambdaPermission",
     "Properties": Object {
@@ -13,111 +37,6 @@ Object {
       "LogGroupName": "/aws/lambda/testing",
     },
     "Type": "AWS::Logs::SubscriptionFilter",
-  },
-  "logHandlerLambdaPermission": Object {
-    "Properties": Object {
-      "Action": "lambda:InvokeFunction",
-      "FunctionName": Object {
-        "Fn::GetAtt": Array [
-          "LogHandlerLambdaFunction",
-          "Arn",
-        ],
-      },
-      "Principal": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "logs.",
-            Object {
-              "Ref": "AWS::Region",
-            },
-            ".amazonaws.com",
-          ],
-        ],
-      },
-    },
-    "Type": "AWS::Lambda::Permission",
-  },
-}
-`;
-
-exports[`Setup LogGroup Subscriptions should setup log group subscriptions to the correct functions 1`] = `
-Object {
-  "TestingLambdaFunctionSubscriptionFilter": Object {
-    "DependsOn": "LoggingLambdaPermission",
-    "Properties": Object {
-      "DestinationArn": Object {
-        "Fn::GetAtt": Array [
-          "LogHandlerLambdaFunction",
-          "Arn",
-        ],
-      },
-      "FilterPattern": "",
-      "LogGroupName": "/aws/lambda/testing",
-    },
-    "Type": "AWS::Logs::SubscriptionFilter",
-  },
-  "TestingLocalFunctionLambdaFunctionSubscriptionFilter": Object {
-    "DependsOn": "LoggingLambdaPermission",
-    "Properties": Object {
-      "DestinationArn": Object {
-        "Fn::GetAtt": Array [
-          "TestLogHandlerLambdaFunction",
-          "Arn",
-        ],
-      },
-      "FilterPattern": "",
-      "LogGroupName": "/aws/lambda/undefined",
-    },
-    "Type": "AWS::Logs::SubscriptionFilter",
-  },
-  "logHandlerLambdaPermission": Object {
-    "Properties": Object {
-      "Action": "lambda:InvokeFunction",
-      "FunctionName": Object {
-        "Fn::GetAtt": Array [
-          "LogHandlerLambdaFunction",
-          "Arn",
-        ],
-      },
-      "Principal": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "logs.",
-            Object {
-              "Ref": "AWS::Region",
-            },
-            ".amazonaws.com",
-          ],
-        ],
-      },
-    },
-    "Type": "AWS::Lambda::Permission",
-  },
-  "testLogHandlerLambdaPermission": Object {
-    "Properties": Object {
-      "Action": "lambda:InvokeFunction",
-      "FunctionName": Object {
-        "Fn::GetAtt": Array [
-          "TestLogHandlerLambdaFunction",
-          "Arn",
-        ],
-      },
-      "Principal": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "logs.",
-            Object {
-              "Ref": "AWS::Region",
-            },
-            ".amazonaws.com",
-          ],
-        ],
-      },
-    },
-    "Type": "AWS::Lambda::Permission",
   },
 }
 `;

--- a/lib/log-inovke-lambda-permission-template.json
+++ b/lib/log-inovke-lambda-permission-template.json
@@ -1,22 +1,24 @@
 {
-    "Type": "AWS::Lambda::Permission",
-    "Properties": {
-        "FunctionName": {
-            "Fn::GetAtt": [
-                "LogHandlerLambdaFunction",
-                "Arn"
-            ]
-        },
-        "Action": "lambda:InvokeFunction",
-        "Principal": {
-            "Fn::Join": [
-                "",
-                [
-                    "logs.",
-                    { "Ref" : "AWS::Region"},
-                    ".amazonaws.com"
+    "LoggingLambdaPermission": {
+        "Type": "AWS::Lambda::Permission",
+        "Properties": {
+            "FunctionName": {
+                "Fn::GetAtt": [
+                    "LogHandlerLambdaFunction",
+                    "Arn"
                 ]
-            ]
+            },
+            "Action": "lambda:InvokeFunction",
+            "Principal": {
+                "Fn::Join": [
+                    "",
+                    [
+                        "logs.",
+                        { "Ref" : "AWS::Region"},
+                        ".amazonaws.com"
+                    ]
+                ]
+            }
         }
     }
 }

--- a/lib/setupLogGroupSubscriptions.js
+++ b/lib/setupLogGroupSubscriptions.js
@@ -12,17 +12,24 @@ function setupLogGroupSubscriptions() {
     this.service = this.serverless.service
     this.logToFunction = this.service.custom.logToFunction || 'logHandler'
 
-    const functionsUsedForLogging = []
+    const permissionTemplatePath = path.join(
+            __dirname,
+            '..',
+            'lib',
+            'log-inovke-lambda-permission-template.json'
+        )
+
+    const permissionTemplate = this.serverless.utils.readFileSync(permissionTemplatePath)
+    permissionTemplate.LoggingLambdaPermission.Properties.FunctionName['Fn::GetAtt'][0] = getNormalizedFunctionName(this.logToFunction)
+
+    _.merge(this.service.provider.compiledCloudFormationTemplate.Resources, permissionTemplate)
 
     this.service.getAllFunctions().forEach((functionName) => {
-        const functionObject = this.service.getFunction(functionName)
-
-        if (functionName === this.logToFunction && !functionObject.logToFunction) {
+        if (functionName === this.logToFunction) {
             return
         }
 
-        const localLogToFunction = functionObject.logToFunction || this.logToFunction
-
+        const functionObject = this.service.getFunction(functionName)
         const templatePath = path.join(
             __dirname,
             '..',
@@ -32,7 +39,7 @@ function setupLogGroupSubscriptions() {
 
         const template = this.serverless.utils.readFileSync(templatePath)
         template.Properties.LogGroupName = `/aws/lambda/${functionObject.name}`
-        template.Properties.DestinationArn['Fn::GetAtt'][0] = getNormalizedFunctionName(localLogToFunction)
+        template.Properties.DestinationArn['Fn::GetAtt'][0] = getNormalizedFunctionName(this.logToFunction)
 
         const functionLogicalId = getNormalizedFunctionName(functionName)
         const newResources = {
@@ -41,26 +48,6 @@ function setupLogGroupSubscriptions() {
 
         const resources = this.service.provider.compiledCloudFormationTemplate.Resources
         _.merge(resources, newResources)
-
-        functionsUsedForLogging.push(localLogToFunction)
-    })
-
-    _.uniq(functionsUsedForLogging).forEach((loggingFunction) => {
-        const permissionTemplatePath = path.join(
-            __dirname,
-            '..',
-            'lib',
-            'log-inovke-lambda-permission-template.json'
-        )
-
-        const permissionTemplate = this.serverless.utils.readFileSync(permissionTemplatePath)
-        permissionTemplate.Properties.FunctionName['Fn::GetAtt'][0] = getNormalizedFunctionName(loggingFunction)
-
-        const functionPermission = {
-            [`${loggingFunction}LambdaPermission`]: permissionTemplate,
-        }
-
-        _.merge(this.service.provider.compiledCloudFormationTemplate.Resources, functionPermission)
     })
 }
 

--- a/lib/setupLogGroupSubscriptions.test.js
+++ b/lib/setupLogGroupSubscriptions.test.js
@@ -4,45 +4,30 @@ const sinon = require('sinon')
 const Serverless = require('serverless')
 
 describe('Setup LogGroup Subscriptions', () => {
-    let serverless
-    let module
+    const serverless = new Serverless()
+    serverless.cli = {
+        log: sinon.spy(),
+        consoleLog: sinon.spy(),
+    }
 
-    beforeEach(() => {
-        serverless = new Serverless()
-        serverless.cli = {
-            log: sinon.spy(),
-            consoleLog: sinon.spy(),
-        }
+    serverless.service.provider.compiledCloudFormationTemplate = {
+        Resources: {},
+    }
 
-        serverless.service.provider.compiledCloudFormationTemplate = {
-            Resources: {},
-        }
+    serverless.service.functions = {
+        testing: {
+            name: 'testing',
+        },
+    }
 
-        serverless.service.functions = {
-            testing: {
-                name: 'testing',
-            },
-        }
+    const baseModule = require('./setupLogGroupSubscriptions') // eslint-disable-line global-require
 
-        const baseModule = require('./setupLogGroupSubscriptions') // eslint-disable-line global-require
-
-        module = Object.assign({
-            serverless,
-            options: {},
-        }, baseModule)
-    })
+    const module = Object.assign({
+        serverless,
+        options: {},
+    }, baseModule)
 
     it('should setup log group subscriptions', () => {
-        module.setupLogGroupSubscriptions()
-        expect(serverless.service.provider.compiledCloudFormationTemplate.Resources)
-            .toMatchSnapshot()
-    })
-
-    it('should setup log group subscriptions to the correct functions', () => {
-        serverless.service.functions.testingLocalFunction = {
-            logToFunction: 'testLogHandler',
-        }
-
         module.setupLogGroupSubscriptions()
         expect(serverless.service.provider.compiledCloudFormationTemplate.Resources)
             .toMatchSnapshot()


### PR DESCRIPTION
Reverts TicketSolutionsPtyLtd/serverless-plugin-cloudwatch-logging-subscriptions#1

PR #1 has a few issues regarding excluding logging from other LogToFunction need to review these change before merging them back, and highlighted another issue regarding create template DependsOn settings